### PR TITLE
[setup] : storybook public 경로 형식 수정

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,6 +13,6 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs',
     options: {},
   },
-  staticDirs: ['..\\public'],
+  staticDirs: ['../public'],
 };
 export default config;


### PR DESCRIPTION
## 🛂 연관된 커밋

> ex) 9a0d61fd4a2ad5270c55b4d4b0c16a15000f98ad

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> .storybook/main.ts 의 staticDirs 경로 형식 수정
- ..\\public -> ../public
- 변경 이유 :  \\ 경로가 맥에서는 제대로 해석하지 못할수도있음

## 💬리뷰 요구사항(선택)

풀 받으시면 스토리북 잘 열리는지 확인부탁드립니다.
