### PR TITLE
[feat] 그룹 생성 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
     "@sentry/nextjs": "^8.34.0",
     "@supabase/ssr": "^0.5.1",
     "@supabase/supabase-js": "^2.45.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^3.9.0
+        version: 3.9.0(react-hook-form@7.53.1(react@18.3.1))
       '@sentry/nextjs':
         specifier: ^8.34.0
         version: 8.34.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.95.0(esbuild@0.23.1))
@@ -903,6 +906,11 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@hookform/resolvers@3.9.0':
+    resolution: {integrity: sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -6244,6 +6252,10 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@hookform/resolvers@3.9.0(react-hook-form@7.53.1(react@18.3.1))':
+    dependencies:
+      react-hook-form: 7.53.1(react@18.3.1)
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,32 @@
+import { createClient } from '@/utils/supabase/server';
+import { NextResponse } from 'next/server';
+
+// The client you created from the Server-Side Auth instructions
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get('code');
+  // if "next" is in param, use it as the redirect URL
+  const next = searchParams.get('next') ?? '/';
+  console.log('searchParams :>> ', searchParams);
+  console.log('origin :>> ', origin);
+  if (code) {
+    const supabase = createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      const forwardedHost = request.headers.get('x-forwarded-host'); // original origin before load balancer
+      const isLocalEnv = process.env.NODE_ENV === 'development';
+      if (isLocalEnv) {
+        // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
+        return NextResponse.redirect(`${origin}${next}`);
+      } else if (forwardedHost) {
+        return NextResponse.redirect(`https://${forwardedHost}${next}`);
+      } else {
+        return NextResponse.redirect(`${origin}${next}`);
+      }
+    }
+  }
+
+  // return the user to an error page with instructions
+  return NextResponse.redirect(`${origin}/auth/auth-code-error`);
+}

--- a/src/app/groupdetail/page.tsx
+++ b/src/app/groupdetail/page.tsx
@@ -1,0 +1,14 @@
+type Props = {
+  searchParams: { group_id: string };
+};
+
+const GroupDetailPage = ({ searchParams: { group_id } }: Props) => {
+  return (
+    <div>
+      <p>GroupDetailPage</p>
+      <p>{group_id}</p>
+    </div>
+  );
+};
+
+export default GroupDetailPage;

--- a/src/app/makegroup/error.tsx
+++ b/src/app/makegroup/error.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import React from 'react';
+
+const Error = ({ error }: { error: Error & { digest?: string } }) => {
+  return (
+    <div>
+      <p>임시 에러페이지</p>
+      <p>{JSON.stringify(error)}</p>
+    </div>
+  );
+};
+
+export default Error;

--- a/src/app/makegroup/page.tsx
+++ b/src/app/makegroup/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useMakeGroupForm } from '@/hooks/byUse/useGroupForm';
+import { useInsertGroupMutation, useInsertUserGroupMutation } from '@/hooks/queries/byUse/useGroupMutations';
+import { makeGroupDataToObj, makeUserGroupDataToObj } from '@/services/groupServices';
+import browserClient from '@/utils/supabase/client';
+import { FieldValues } from 'react-hook-form';
+
+const MakeGroupPage = () => {
+  const { register, handleSubmit, formState } = useMakeGroupForm();
+
+  const { isError: insertGroupDataError, mutateAsync: insertGroupDataMutate } = useInsertGroupMutation();
+  const { isError: insertUserGroupError, mutate: insertUserGroupMutate } = useInsertUserGroupMutation();
+
+  const onSubmit = async (value: FieldValues) => {
+    const groupObj = makeGroupDataToObj(value);
+    await insertGroupDataMutate(groupObj);
+    //NOTE - user관련 store생성 후 userId 수정 필요
+    const { data } = await browserClient.auth.getUser();
+    if (data.user?.id) {
+      const userGroupObj = makeUserGroupDataToObj(data.user?.id, true, groupObj.group_id);
+      insertUserGroupMutate(userGroupObj);
+    }
+  };
+
+  const loginWithGithub = async () => {
+    await browserClient.auth.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: window.origin + '/auth/callback',
+      },
+    });
+  };
+  const logout = async () => {
+    await browserClient.auth.signOut();
+  };
+
+  if (insertGroupDataError || insertUserGroupError) throw new Error('에러 발생!');
+  return (
+    <div className='flex flex-col justify-center items-center gap-[20px] my-[20px] py-[10px]'>
+      <button onClick={loginWithGithub}>깃허브테스트로그인</button>
+      <button onClick={logout}>깃허브테스트로그아웃</button>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className='flex flex-col justify-center items-center gap-[30px]'
+      >
+        <div className='p-[10px] border border-solid border-black w-[500px]'>
+          <label htmlFor='group_title'>그룹명</label>
+          <input
+            id='group_title'
+            {...register('groupTitle')}
+            type='text'
+            placeholder='그룹명'
+          />
+          {formState.errors.groupTitle && <p>{formState.errors.groupTitle.message}</p>}
+        </div>
+        <div className='p-[10px] border border-solid border-black w-[500px]'>
+          <label htmlFor='group_desc'>그룹상세내용</label>
+          <input
+            id='group_desc'
+            {...register('groupDesc')}
+            type='text'
+            placeholder='그룹정보'
+          />
+          {formState.errors.groupDesc && <p>{formState.errors.groupDesc.message}</p>}
+        </div>
+        <button
+          className='cursor-pointer hover:bg-slate-300 p-[10px]'
+          type='submit'
+        >
+          그룹 생성
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default MakeGroupPage;

--- a/src/hooks/byUse/useGroupForm.ts
+++ b/src/hooks/byUse/useGroupForm.ts
@@ -1,0 +1,16 @@
+import { groupSchema } from '@/schemas/groupSchemas';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+const useMakeGroupForm = () => {
+  return useForm({
+    mode: 'onSubmit',
+    defaultValues: {
+      groupTitle: '',
+      groupDesc: '',
+    },
+    resolver: zodResolver(groupSchema),
+  });
+};
+
+export { useMakeGroupForm };

--- a/src/hooks/queries/byUse/useGroupMutations.ts
+++ b/src/hooks/queries/byUse/useGroupMutations.ts
@@ -1,0 +1,28 @@
+import { insertGroupData, insertUserGroupData } from '@/services/client-action/groupActions';
+import { GroupObjType, UserGroupType } from '@/types/groupTypes';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+// TODO - invalidate필요시 쿼리키 추가 필요
+const useInsertGroupMutation = () => {
+  return useMutation({
+    mutationFn: async (groupObj: GroupObjType) => await insertGroupData(groupObj),
+    onSuccess: (data) => {
+      // console.log('data :>> ', data);
+    },
+    onError: (error) => console.log('error :>> ', error),
+  });
+};
+
+const useInsertUserGroupMutation = () => {
+  const router = useRouter();
+  return useMutation({
+    mutationFn: async (userGroupObj: UserGroupType) => await insertUserGroupData(userGroupObj),
+    onSuccess: (data) => {
+      router.push(`/groupdetail?group_id=${data?.groupId}`);
+    },
+    onError: (error) => console.log('error :>> ', error),
+  });
+};
+
+export { useInsertGroupMutation, useInsertUserGroupMutation };

--- a/src/schemas/groupSchemas.ts
+++ b/src/schemas/groupSchemas.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+const groupSchema = z.object({
+  groupTitle: z
+    .string({ message: '그룹명을 입력해주세요!' })
+    .min(1, { message: '그룹명은 1글자 이상 10글자 이하여야 합니다.' })
+    .max(10, { message: '그룹명은 1글자 이상 10글자 이하여야 합니다.' }),
+  groupDesc: z.string(),
+});
+
+export { groupSchema };

--- a/src/services/client-action/groupActions.ts
+++ b/src/services/client-action/groupActions.ts
@@ -2,13 +2,13 @@ import { GroupObjType, UserGroupType } from '@/types/groupTypes';
 import browserClient from '@/utils/supabase/client';
 
 const insertGroupData = async (groupObj: GroupObjType) => {
-  const state = await browserClient.from('group').insert([groupObj]);
+  const state = await browserClient.from('group').insert(groupObj);
   if (state.status !== 201) throw state.error;
   else if (state.status === 201) return { data: state.data, error: state.error };
 };
 
 const insertUserGroupData = async (userGroupObj: UserGroupType) => {
-  const state = await browserClient.from('user_group').insert([userGroupObj]);
+  const state = await browserClient.from('user_group').insert(userGroupObj);
   if (state.status !== 201) throw state.error;
   else if (state.status === 201) return { data: state.data, error: state.error, groupId: userGroupObj.group_id };
 };

--- a/src/services/client-action/groupActions.ts
+++ b/src/services/client-action/groupActions.ts
@@ -1,0 +1,16 @@
+import { GroupObjType, UserGroupType } from '@/types/groupTypes';
+import browserClient from '@/utils/supabase/client';
+
+const insertGroupData = async (groupObj: GroupObjType) => {
+  const state = await browserClient.from('group').insert([groupObj]);
+  if (state.status !== 201) throw state.error;
+  else if (state.status === 201) return { data: state.data, error: state.error };
+};
+
+const insertUserGroupData = async (userGroupObj: UserGroupType) => {
+  const state = await browserClient.from('user_group').insert([userGroupObj]);
+  if (state.status !== 201) throw state.error;
+  else if (state.status === 201) return { data: state.data, error: state.error, groupId: userGroupObj.group_id };
+};
+
+export { insertGroupData, insertUserGroupData };

--- a/src/services/groupServices.ts
+++ b/src/services/groupServices.ts
@@ -1,0 +1,24 @@
+import { GroupObjType, UserGroupType } from '@/types/groupTypes';
+import { FieldValues } from 'react-hook-form';
+
+const makeGroupDataToObj = (value: FieldValues): GroupObjType => {
+  return {
+    group_id: crypto.randomUUID(),
+    group_title: value.groupTitle,
+    group_desc: value.groupDesc,
+    group_invite_code: crypto.randomUUID(),
+    group_status: 'recruiting',
+    created_at: new Date(),
+  };
+};
+
+const makeUserGroupDataToObj = (userId: string, is_owner: boolean, group_id: string): UserGroupType => {
+  return {
+    user_id: userId,
+    group_id,
+    is_owner,
+    joined_at: new Date(),
+  };
+};
+
+export { makeGroupDataToObj, makeUserGroupDataToObj };

--- a/src/types/groupTypes.ts
+++ b/src/types/groupTypes.ts
@@ -1,0 +1,15 @@
+export type GroupObjType = {
+  group_id: string;
+  group_title: string;
+  group_desc: string;
+  group_invite_code: string;
+  group_status: string;
+  created_at: Date;
+};
+
+export type UserGroupType = {
+  user_id: string;
+  group_id: string;
+  is_owner: boolean;
+  joined_at: Date;
+};

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -3,3 +3,7 @@ import { createBrowserClient } from '@supabase/ssr';
 export function createClient() {
   return createBrowserClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
 }
+
+const browserClient = createClient();
+
+export default browserClient;


### PR DESCRIPTION
## 🛂 연관된 커밋

> ex) 926d106

## 📝작업 내용

> 그룹 생성 후 그룹 상세페이지로 이동하는 기능 추가

### 스크린샷 (선택)

- 따로 정책은 지정하지 않아서 제한은 저렇게 두었습니다.
![image](https://github.com/user-attachments/assets/081c9254-77c7-4eff-853e-6d9edec4b302)
- hook-form과 zod에 의한 유효성검사는 submit시 하도록 하였습니다.
![image](https://github.com/user-attachments/assets/a1387e35-852b-4018-8050-e568ef1bec82)
- insert 성공 시 status가 201로 들어오기 때문에 201이 아닐 시 throw err / 201 시 return 하였습니다.
![image](https://github.com/user-attachments/assets/e07299ff-5eb2-476f-8457-6131ff2e4ef9)
- 아직 관리할 쿼리키가 없는 것 같아 invalidate하지 않았습니다. 위에서 throw err를 한다면 onError로 들어와 isError = true가 되고 page.tsx에서 isError가 true일 시 throw err을 진행하여 에러페이지로 이동되도록 하였습니다.
![image](https://github.com/user-attachments/assets/cdefc865-4db0-4769-80ac-0f695f53471f)
- 처음에 그룹생성 -> 유저-그룹테이블 추가 이 부분에서 비동기로 처리되어 그룹이 생성되기 전에 유저-그룹테이블에 row를 추가하려하여 에러가 발생했었는데, 해당부분 mutate가 아닌 **mutateAsync**사용하여 동기적으로 처리되도록 변경하였습니다.
![image](https://github.com/user-attachments/assets/a0de3ac9-3a78-436c-a890-568c8b60c9ee)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> useForm, schema, useMutation, supabase.insert 관련 로직 모두 분리했는데 적절할까요?
> 정책관련 아이디어있으면 말씀주시거나 수정부탁드립니다!
