### PR TITLE
[Feat] : 이메일 회원가입

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const page = () => {
+  return <div></div>;
+};
+
+export default page;

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,13 @@
+import SignUpForm from '@/components/auth/SignUpForm';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '회원가입',
+  description: '회원가입',
+};
+
+const SignUpPage = () => {
+  return <SignUpForm />;
+};
+
+export default SignUpPage;

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useSignUpForm } from '@/hooks/byUse/useAuthForm';
+import { useSignUp } from '@/hooks/queries/byUse/useAuthMutations';
+import { signUpSchema } from '@/schemas/authSchemas';
+import { Button } from '@/stories/Button';
+import { Input } from '@/stories/Input';
+import React from 'react';
+import { FieldValues } from 'react-hook-form';
+
+const SignUpForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useSignUpForm();
+
+  const { mutate: signUp } = useSignUp();
+
+  const handleSignUp = async (value: FieldValues) => {
+    signUp(signUpSchema.parse(value));
+  };
+
+  return (
+    <div>
+      <form
+        onSubmit={handleSubmit(handleSignUp)}
+        className='flex flex-col gap-5 w-96'
+      >
+        <Input
+          label={'Email'}
+          placeholder={'이메일'}
+          {...register('email')}
+        />
+        {errors.email && <p className='text-red-500 text-sm pl-1'>{String(errors.email.message)}</p>}
+
+        <Input
+          label={'비밀번호'}
+          type={'password'}
+          placeholder={'비밀번호'}
+          {...register('password')}
+        />
+        {errors.password && <p className='text-red-500 text-sm pl-1'>{String(errors.password.message)}</p>}
+
+        <Input
+          label={'nickname'}
+          placeholder={'닉네임'}
+          {...register('nickname')}
+        />
+        {errors.nickname && <p className='text-red-500 text-sm pl-1'>{String(errors.nickname.message)}</p>}
+
+        <Button
+          type='submit'
+          label='회원가입'
+          primary={true}
+        />
+      </form>
+    </div>
+  );
+};
+
+export default SignUpForm;

--- a/src/constants/authMessage.ts
+++ b/src/constants/authMessage.ts
@@ -1,0 +1,3 @@
+export const ERROR_SIGN_UP = '회원가입 중 문제가 발생했습니다. 다시 시도해주세요.';
+export const SUCCESS_SIGN_UP = '회원가입이 완료되었습니다.';
+export const Is_EXIST_EMAIL = '이미 사용 중인 이메일입니다.';

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,0 +1,1 @@
+export const LOGIN_PAGE = '/login';

--- a/src/hooks/byUse/useAuthForm.ts
+++ b/src/hooks/byUse/useAuthForm.ts
@@ -1,0 +1,12 @@
+import { signUpSchema } from '@/schemas/authSchemas';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+const useSignUpForm = () => {
+  return useForm({
+    mode: 'onChange',
+    resolver: zodResolver(signUpSchema),
+  });
+};
+
+export { useSignUpForm };

--- a/src/hooks/queries/byUse/useAuthMutations.ts
+++ b/src/hooks/queries/byUse/useAuthMutations.ts
@@ -1,0 +1,19 @@
+import { LOGIN_PAGE } from '@/constants/urls';
+import { signUp } from '@/services/server-action/authActions';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+export const useSignUp = () => {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: signUp,
+    onSuccess: (data) => {
+      alert(data.message);
+      router.push(LOGIN_PAGE);
+    },
+    onError: (error) => {
+      alert(error.message);
+    },
+  });
+};

--- a/src/schemas/authSchemas.ts
+++ b/src/schemas/authSchemas.ts
@@ -12,9 +12,14 @@ const signUpSchema = z.object({
   password: z.string().min(6, {
     message: '비밀번호는 6자 이상이어야 합니다.',
   }),
-  nickname: z.string().min(1, {
-    message: '닉네임을 입력해주세요.',
-  }),
+  nickname: z
+    .string()
+    .min(1, {
+      message: '닉네임을 입력해주세요.',
+    })
+    .min(2, {
+      message: '닉네임은 두 글자 이상 입력해주세요.',
+    }),
 });
 
 export { signUpSchema };

--- a/src/schemas/authSchemas.ts
+++ b/src/schemas/authSchemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+const signUpSchema = z.object({
+  email: z
+    .string()
+    .min(1, {
+      message: '이메일을 입력해주세요.',
+    })
+    .email({
+      message: '이메일 형식으로 입력해주세요.',
+    }),
+  password: z.string().min(6, {
+    message: '비밀번호는 6자 이상이어야 합니다.',
+  }),
+  nickname: z.string().min(1, {
+    message: '닉네임을 입력해주세요.',
+  }),
+});
+
+export { signUpSchema };

--- a/src/services/server-action/authActions.ts
+++ b/src/services/server-action/authActions.ts
@@ -1,0 +1,57 @@
+'use server';
+
+import { ERROR_SIGN_UP, Is_EXIST_EMAIL, SUCCESS_SIGN_UP } from '@/constants/authMessage';
+import { createClient } from '@/utils/supabase/server';
+
+/** 이메일 중복 체크 */
+const checkExistEmail = async (email: string) => {
+  const supabase = createClient();
+
+  const { data, error } = await supabase.from('profiles').select('user_email').eq('user_email', email);
+
+  if (error) {
+    console.log('이메일 중복 체크 중 오류 발생', error.message);
+    return { error: ERROR_SIGN_UP };
+  }
+
+  if (data && data.length > 0) {
+    return { isExists: true };
+  }
+
+  return { isExists: false };
+};
+
+export const signUp = async (formData: { email: string; password: string; nickname: string }) => {
+  const supabase = createClient();
+
+  const { error: checkEmailError, isExists } = await checkExistEmail(formData.email);
+
+  /** 일반 오류 */
+  if (checkEmailError) {
+    throw new Error(checkEmailError);
+  }
+
+  /** 중복 이메일 오류 */
+  if (isExists) {
+    throw new Error(Is_EXIST_EMAIL);
+  }
+
+  /** 회원가입 시도 */
+  const { error: signUpError } = await supabase.auth.signUp({
+    email: formData.email,
+    password: formData.password,
+    options: {
+      data: {
+        user_nickname: formData.nickname,
+      },
+    },
+  });
+
+  /** 일반 오류 */
+  if (signUpError) {
+    console.log('회원가입 중 오류 발생', signUpError.message);
+    throw new Error('ERROR_SIGN_UP');
+  }
+
+  return { message: SUCCESS_SIGN_UP };
+};

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -26,6 +26,7 @@ type Story = StoryObj<typeof meta>;
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Primary: Story = {
   args: {
+    type: 'button',
     primary: true,
     label: 'Button',
   },
@@ -33,12 +34,14 @@ export const Primary: Story = {
 
 export const Secondary: Story = {
   args: {
+    type: 'button',
     label: 'Button',
   },
 };
 
 export const Large: Story = {
   args: {
+    type: 'button',
     size: 'large',
     label: 'Button',
   },
@@ -46,6 +49,7 @@ export const Large: Story = {
 
 export const Small: Story = {
   args: {
+    type: 'button',
     size: 'small',
     label: 'Button',
   },

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -2,7 +2,7 @@ import './button.css';
 import React from 'react';
 
 export interface ButtonProps {
-  /** Is this the principal call to action on the page? */
+  type: 'button' | 'submit' | 'reset' /** Is this the principal call to action on the page? */;
   primary?: boolean;
   /** What background color to use */
   backgroundColor?: string;
@@ -18,6 +18,7 @@ export interface ButtonProps {
 
 /** Primary UI component for user interaction */
 export const Button = ({
+  type,
   primary = false,
   size = 'medium',
   backgroundColor,
@@ -29,7 +30,7 @@ export const Button = ({
 
   return (
     <button
-      type='button'
+      type={type}
       className={['storybook-button', `storybook-button--${size}`, mode, className].join(' ')} // className 추가
       {...props}
     >

--- a/src/stories/Header.tsx
+++ b/src/stories/Header.tsx
@@ -50,6 +50,7 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
               Welcome, <b>{user.name}</b>!
             </span>
             <Button
+              type='button'
               size='small'
               onClick={onLogout}
               label='Log out'
@@ -58,11 +59,13 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
         ) : (
           <>
             <Button
+              type='button'
               size='small'
               onClick={onLogin}
               label='Log in'
             />
             <Button
+              type='button'
               primary
               size='small'
               onClick={onCreateAccount}

--- a/src/stories/Input.tsx
+++ b/src/stories/Input.tsx
@@ -36,9 +36,10 @@
 //   )
 // }
 import { cn } from '@/lib/utils';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 export interface InputProps {
+  type?: string;
   /** Label for the input */
   label: string;
   /** Placeholder text for the input */
@@ -54,36 +55,34 @@ export interface InputProps {
 }
 
 /** Primary UI component for user interaction */
-export const Input = ({
-  label,
-  placeholder = '',
-  disabled = false,
-  size = 'medium',
-  backgroundColor,
-  ...props
-}: InputProps) => {
-  const sizeClasses = {
-    small: 'py-1 px-2 text-sm',
-    medium: 'py-2 px-3 text-base',
-    large: 'py-3 px-4 text-lg',
-  };
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ type, label, placeholder = '', disabled = false, size = 'medium', backgroundColor, ...props }, ref) => {
+    const sizeClasses = {
+      small: 'py-1 px-2 text-sm',
+      medium: 'py-2 px-3 text-base',
+      large: 'py-3 px-4 text-lg',
+    };
 
-  return (
-    <div className='mb-4'>
-      <label className='block text-fuchsia-700 font-bold mb-2'>{label}</label>
-      <input
-        type='text'
-        placeholder={placeholder}
-        disabled={disabled}
-        className={cn(
-          'border rounded-md w-full',
-          sizeClasses[size],
-          'focus:outline-none focus:ring-2 focus:ring-fuchsia-500 focus:border-transparent',
-          disabled ? 'bg-gray-200 cursor-not-allowed' : 'bg-white',
-        )}
-        style={{ backgroundColor }}
-        {...props}
-      />
-    </div>
-  );
-};
+    return (
+      <div className='mb-4'>
+        <label className='block text-fuchsia-700 font-bold mb-2'>{label}</label>
+        <input
+          ref={ref}
+          type={type}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={cn(
+            'border rounded-md w-full',
+            sizeClasses[size],
+            'focus:outline-none focus:ring-2 focus:ring-fuchsia-500 focus:border-transparent',
+            disabled ? 'bg-gray-200 cursor-not-allowed' : 'bg-white',
+          )}
+          style={{ backgroundColor }}
+          {...props}
+        />
+      </div>
+    );
+  },
+);
+
+// Input.displayName = 'Input';


### PR DESCRIPTION
## 🛂 연관된 커밋

> 65b4fcf95db4ea2becfda602c6bec0f18414ebdb


## 📝작업 내용

> 이메일 회원가입

- 회원가입 시 auth Users 와 public 의 profiles 두 테이블에 모두 저장

### 스크린샷 (선택)

- 메타데이터 넣었습니다.
![스크린샷 2024-10-22 오후 2 56 27](https://github.com/user-attachments/assets/36796d52-a5b2-4bbe-851a-6ee955dc3a0e)


- 텐스텍 쿼리 사용하였고, Input 은 만들어져있는 공통 컴포넌트 사용해봤습니다.
![스크린샷 2024-10-22 오후 2 57 32](https://github.com/user-attachments/assets/50323190-546e-4acd-be9a-2209a7f7ef0c)

- 회원가입 만들면서 상수로 관리하면 좋을것같은 것들 상수로 만들어봤습니다. 
![스크린샷 2024-10-22 오후 2 58 39](https://github.com/user-attachments/assets/a035192b-d31a-47dd-937c-9e1caf3a6e9e)

- 이메일 중복체크도 했습니다.
![스크린샷 2024-10-22 오후 2 59 54](https://github.com/user-attachments/assets/c36db3ce-2574-4584-b348-b466f2118062)

## 💬리뷰 요구사항(선택)

> 오류메세지랑 url 상수 파일 만들었는데 파일명이나 다른 방식으로 관리했으면 하는 의견 있으시면 말씀부탁드립니다!!

튜터님 수파베이스를 활용한 회원가입 기능 PR 입니다 :>
@jiji-hoon96
