### PR TITLE
[Feat] 그룹 리스트페이지 랜덤이미지 및 그룹 리스트 무한스크롤 기능 추가

### DIFF
--- a/src/app/grouplist/page.tsx
+++ b/src/app/grouplist/page.tsx
@@ -1,10 +1,37 @@
 import GroupList from '@/components/groupList/GroupList';
 import RandomImage from '@/components/groupList/RandomImage';
+import { getGroupPostLists } from '@/services/server-action/groupServerActions';
+import { createClient } from '@/utils/supabase/server';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 
-const GroupListPage = () => {
+const GroupListPage = async () => {
+  // const queryClient = new QueryClient({
+  //   defaultOptions: {
+  //     queries: {
+  //       staleTime: 1000 * 60 * 10,
+  //     },
+  //   },
+  // });
+  // const supabase = createClient();
+  // const { data } = await supabase.auth.getUser();
+
+  // await queryClient.prefetchQuery({
+  //   queryKey: ['groupImages'],
+  //   queryFn: async () => {
+  //     let images = [];
+  //     if (data.user?.id) {
+  //       const userId = data.user.id;
+  //       const belongGroups = await getGroupPostLists(userId);
+  //       console.log('belongGroups :>> ', belongGroups);
+  //     }
+  //     return;
+  //   },
+  // });
   return (
     <div className='px-[16px] flex flex-col justify-center items-center'>
+      {/* <HydrationBoundary state={dehydrate(queryClient)}> */}
       <RandomImage />
+      {/* </HydrationBoundary> */}
       <GroupList />
     </div>
   );

--- a/src/components/groupList/RandomImage.tsx
+++ b/src/components/groupList/RandomImage.tsx
@@ -1,5 +1,52 @@
+'use client';
+
+import { getSignedImgUrl } from '@/services/server-action/getSignedImgUrl';
+import browserClient from '@/utils/supabase/client';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
 const RandomImage = () => {
-  return <div>RandomImage</div>;
+  const { data, isPending, isError, refetch } = useQuery({
+    queryKey: ['groupImages'],
+    queryFn: async () => {
+      const { data } = await browserClient.auth.getUser();
+      let url = '';
+      if (data.user?.id) {
+        const userId = data.user.id;
+        const { data: randomGroupData, error: randomGroupError } = await browserClient.rpc('get_group_id_by_user', {
+          insert_user_id: userId,
+        });
+        if (randomGroupData) {
+          const { data: thumbnailData, error: thumbnailError } = await browserClient.rpc(
+            'get_group_thumbnail_by_group_id',
+            {
+              input_group_id: randomGroupData,
+            },
+          );
+          if (thumbnailData) url = (await getSignedImgUrl('tour_images', 20, `/group_name/${thumbnailData}`)) as string;
+        }
+      }
+      return url;
+    },
+  });
+  useEffect(() => {
+    const refetchInterval = setInterval(() => {
+      refetch();
+    }, 1000 * 10);
+    refetchInterval;
+    return () => clearInterval(refetchInterval);
+  });
+  return (
+    <div>
+      {data && (
+        <img
+          src={data}
+          alt=''
+          className='w-[343px] h-[172px] object-contain'
+        />
+      )}
+    </div>
+  );
 };
 
 export default RandomImage;

--- a/src/services/server-action/groupServerActions.ts
+++ b/src/services/server-action/groupServerActions.ts
@@ -17,4 +17,22 @@ const getGroupDetails = async (group_id: string) => {
   }
 };
 
-export { getGroupDetails };
+type PostLists = {
+  group_id: string;
+};
+
+const getGroupPostLists = async (user_id: string) => {
+  const supabase = createClient();
+  const { data, error } = await supabase.from('user_group').select('group_id').eq('user_id', user_id).limit(10);
+  if (error) throw error;
+  return data as PostLists[];
+};
+
+const getPostListsByGroupId = async (group_id: string) => {
+  const supabase = createClient();
+  const { data, error } = await supabase.from('post').select('post_thumbnail_image').eq('group_id', group_id).single();
+  if (error) throw error;
+  return data;
+};
+
+export { getGroupDetails, getGroupPostLists, getPostListsByGroupId };

--- a/src/services/server-action/groupServerActions.ts
+++ b/src/services/server-action/groupServerActions.ts
@@ -35,4 +35,24 @@ const getPostListsByGroupId = async (group_id: string) => {
   return data;
 };
 
-export { getGroupDetails, getGroupPostLists, getPostListsByGroupId };
+const getRandomGroupId = async (userId: string) => {
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc('get_group_id_by_user', {
+    insert_user_id: userId,
+  });
+  if (data) return data as string;
+  return null;
+};
+
+const getRandomThumbnail = async (groupId: string) => {
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc('get_group_thumbnail_by_group_id', {
+    input_group_id: groupId,
+  });
+  //NOTE - 썸네일 이미지, created_at, post_address도 같이 가져와야함
+  //근데 어떻게 고쳐야할지 모르겠음
+  if (data) return data as string;
+  return null;
+};
+
+export { getGroupDetails, getGroupPostLists, getPostListsByGroupId, getRandomGroupId, getRandomThumbnail };

--- a/src/utils/getRandomElement.ts
+++ b/src/utils/getRandomElement.ts
@@ -1,0 +1,4 @@
+export const getRandomElement = (array: any[]) => {
+  const randomIndex = Math.floor(Math.random() * array.length);
+  return array[randomIndex];
+};


### PR DESCRIPTION
## 🛂 연관된 커밋

> 1b656f2eb8d83d27c465468c3fcfdd2b1a465024
> 651e81a692be68aae9d27c14fc07d5fb156d85ff

## #️⃣연관된 이슈

> 이슈생성예정

## 📝작업 내용

> 그룹 리스트 불러오는 기능 추가
> 랜덤 이미지 불러오는 기능 추가 및 supabase function생성

### 스크린샷 
![refetch](https://github.com/user-attachments/assets/db6bcadc-e70c-42fc-a582-9d15b0c094df)

## 💬리뷰 요구사항

> 페이지 진입 시 supabase 관련 fetch 요청이 최소 16개가 넘어가는 상황인데 이걸 sql 을 사용해서 function으로 만들어 최적화를 시키고 싶은데 그 과정이 너무 감당이 안됩니다
> 근데 또 안하면 첫 로딩시에 랜덤이미지를 불러오는데 2초가 걸리거나 0.4초가 걸려서 function으로 좀 모을 필요가 있을것 같은데 어떻게 해야할까요
